### PR TITLE
Add further state machine and state machine async test cases.

### DIFF
--- a/Tests/NStateManager.Tests/NStateManager.Tests.csproj
+++ b/Tests/NStateManager.Tests/NStateManager.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="StateTransitionAsyncTests.cs" />
     <Compile Include="StateTransitionParameterizedTests.cs" />
     <Compile Include="SubStateTest.cs" />
+    <Compile Include="TestRequest.cs" />
     <Compile Include="TriggerActionParameterizedTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/NStateManager.Tests/StateMachineAsyncTests.cs
+++ b/Tests/NStateManager.Tests/StateMachineAsyncTests.cs
@@ -565,36 +565,27 @@ namespace NStateManager.Tests
         [Fact]
         public async Task FireTriggerAsyncWRequest_withReferenceTypeInstance_triggerExecutes()
         {
-            var testRequest = new Request(123.45);
+            var testRequest = new TestRequest(123.45);
 
             var sut = new StateMachineAsync<Sale, SaleState, SaleEvent>(
                 stateAccessor: sale2 => sale2.State
                 , stateMutator: (sale3, newState) => sale3.State = newState);
 
             sut.ConfigureState(SaleState.Open)
-                .AddTriggerAction<Request>(SaleEvent.Pay, async (saleInstance, request, token) =>
+                .AddTriggerAction<TestRequest>(SaleEvent.Pay, async (saleInstance, request, token) =>
                 {
                     saleInstance.Balance = request.Value;
-                    await Task.Delay(100);
+                    await Task.Delay(10);
                 })
                 .AddTransition(SaleEvent.Pay, SaleState.Complete);
 
             var sale = new Sale(saleID: 45) { State = SaleState.Open };
-            var stateTransitionResult = await sut.FireTriggerAsync<Request>(sale, SaleEvent.Pay, testRequest);
+            var stateTransitionResult = await sut.FireTriggerAsync<TestRequest>(sale, SaleEvent.Pay, testRequest);
 
             Assert.NotNull(stateTransitionResult);
             Assert.Equal(SaleState.Complete, stateTransitionResult.CurrentState);
             Assert.Equal(SaleState.Complete, sale.State);
             Assert.Equal(sale.Balance, testRequest.Value);
-        }
-    }
-
-    public sealed class Request
-    {
-        public double Value { get; }
-        public Request(double value)
-        {
-            Value = value;
         }
     }
 }

--- a/Tests/NStateManager.Tests/TestRequest.cs
+++ b/Tests/NStateManager.Tests/TestRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace NStateManager.Tests
+{
+    /// <summary>
+    /// A test request payload for use in <see cref="StateMachineAsync{T,TState,TTrigger}.FireTriggerAsync{Result}"/> calls
+    /// </summary>
+    public sealed class TestRequest
+    {
+        public double Value { get; }
+        public TestRequest(double value)
+        {
+            Value = value;
+        }
+    }
+}


### PR DESCRIPTION
Tests and improvement of previously added test from part of the investigation work into resolving the upcoming issue: AddTransition<Request> never runs when triggered in async StateMachine.